### PR TITLE
Isoform sequence import

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ bucketSuffix  := "era7.com"
 scalaVersion := "2.11.8"
 
 libraryDependencies ++= Seq (
-  "bio4j"                   % "bio4j"               % "0.12.0-169-g5b2be3b",
+  "bio4j"                   % "bio4j"               % "0.12.0-170-g5f8af9d",
   "org.scala-lang.modules" %% "scala-xml"           % "1.0.5",
   "org.scala-lang.modules" %% "scala-java8-compat"  % "0.8.0-RC3",
   "ohnosequences"          %% "fastarious"          % "0.6.0"

--- a/build.sbt
+++ b/build.sbt
@@ -9,12 +9,12 @@ scalaVersion := "2.11.8"
 libraryDependencies ++= Seq (
   "bio4j"                   % "bio4j"               % "0.12.0-169-g5b2be3b",
   "org.scala-lang.modules" %% "scala-xml"           % "1.0.5",
-  "org.scala-lang.modules" %% "scala-java8-compat"  % "0.8.0-RC3"
+  "org.scala-lang.modules" %% "scala-java8-compat"  % "0.8.0-RC3",
+  "ohnosequences"          %% "fastarious"          % "0.6.0"
 ) ++ testDependencies
 
 lazy val testDependencies = Seq (
-  "org.scalatest"         %% "scalatest"    % "2.2.6"   % Test,
-  "com.github.pathikrit"  %% "better-files" % "2.16.0"  % Test
+  "org.scalatest"         %% "scalatest"    % "2.2.6"   % Test
 )
 
 dependencyOverrides := Set (

--- a/src/main/scala/uniprot/isoformsFasta.scala
+++ b/src/main/scala/uniprot/isoformsFasta.scala
@@ -1,0 +1,13 @@
+package com.bio4j.data.uniprot
+
+import ohnosequences.fastarious._, fasta._
+
+case class IsoformFasta(val fa: FASTA.Value) extends AnyVal {
+
+  def proteinID: String =
+    // the format of the id is 'sp|${id}|otherstuff'
+    fa.getV(fasta.header).id.stripPrefix("sp|").takeWhile(_ != '|')
+
+  def sequence: String =
+    fa.getV(fasta.sequence).value
+}

--- a/src/main/scala/uniprot/uniprot.scala
+++ b/src/main/scala/uniprot/uniprot.scala
@@ -213,7 +213,7 @@ case class Process[V,E](val graph: UniProtGraph[V,E]) {
 
           isoform
           .set(g.protein.sequence, seq)
-          // .set(g.protein.length, seq.length) after bio4j/bio4j#144
+          .set(g.protein.sequenceLength, seq.length: java.lang.Integer)
         }
 
         (graph, isoformOpt)

--- a/src/main/scala/uniprot/uniprot.scala
+++ b/src/main/scala/uniprot/uniprot.scala
@@ -199,4 +199,24 @@ case class Process[V,E](val graph: UniProtGraph[V,E]) {
         (graph, importedIsoforms)
       }
     )
+
+  val isoformSequences =
+    GraphProcess.generically[V,E](
+      graph,
+      (fasta: IsoformFasta, g: G) => {
+
+        val isoformOpt = g.protein.id.index.find(fasta.proteinID).asScala
+
+        isoformOpt.foreach {
+          isoform =>
+          val seq = fasta.sequence
+
+          isoform
+          .set(g.protein.sequence, seq)
+          // .set(g.protein.length, seq.length) after bio4j/bio4j#144
+        }
+
+        (graph, isoformOpt)
+      }
+    )
 }


### PR DESCRIPTION
The isoform sequences are here:
- ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_sprot_varsplic.fasta.gz

About `28MB` uncompressed.
- [ ] The file name could mean that TrEMBL contains no isoforms; confirm this
- [x] The sequence length (and thus the protein) is also imported here, as it is not part of the entry data; the header format is
  
  ```
  sp|Q29960-2|1C16_HUMAN Isoform 2 of HLA class I histocompatibility antigen, Cw-16 alpha chain OS=Homo sapiens GN=HLA-C
  ```
