### PR TITLE
Drop UniProt XML, use data.uniprot

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ scalaVersion := "2.11.8"
 
 libraryDependencies ++= Seq (
   "bio4j"                   % "bio4j"               % "0.12.0-227-g60cce98",
+  "bio4j"                  %% "data-uniprot"        % "0.1.0",
   "org.scala-lang.modules" %% "scala-xml"           % "1.0.5",
   "org.scala-lang.modules" %% "scala-java8-compat"  % "0.8.0-RC3",
   "ohnosequences"          %% "fastarious"          % "0.6.0"
@@ -19,7 +20,8 @@ lazy val testDependencies = Seq (
 
 dependencyOverrides := Set (
   "org.scala-lang.modules" %% "scala-xml"     % "1.0.5",
-  "org.scala-lang"         %  "scala-library" % "2.11.8"
+  "org.scala-lang"         %  "scala-library" % "2.11.8",
+  "com.github.pathikrit"   %% "better-files"  % "2.13.0"
 )
 
 wartremoverExcluded ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ scalaVersion := "2.11.8"
 
 libraryDependencies ++= Seq (
   "bio4j"                   % "bio4j"               % "0.12.0-227-g60cce98",
-  "bio4j"                  %% "data-uniprot"        % "0.1.0",
+  "bio4j"                  %% "data-uniprot"        % "0.1.1",
   "org.scala-lang.modules" %% "scala-xml"           % "1.0.5",
   "org.scala-lang.modules" %% "scala-java8-compat"  % "0.8.0-RC3",
   "ohnosequences"          %% "fastarious"          % "0.6.0"

--- a/src/main/scala/uniprot/conversions.scala
+++ b/src/main/scala/uniprot/conversions.scala
@@ -2,7 +2,6 @@ package com.bio4j.data.uniprot
 
 import com.bio4j.model._
 import com.bio4j.angulillos._
-import scala.xml._
 import scala.compat.java8.OptionConverters._
 import bio4j.data.uniprot._
 
@@ -80,7 +79,12 @@ case object conversions {
       case TURN       => UniProtGraph.FeatureTypes.turn
     }
 
-  
+  def commentTopic(c: Comment): UniProtGraph.CommentTopics =
+    c match {
+      case _ => ???
+    }
+
+
 
   val stringToGeneLocation: String => UniProtGraph.GeneLocations =
     {

--- a/src/main/scala/uniprot/conversions.scala
+++ b/src/main/scala/uniprot/conversions.scala
@@ -79,6 +79,12 @@ case object conversions {
       case TURN       => UniProtGraph.FeatureTypes.turn
     }
 
+  def featureFromAsInt(from: String): Int =
+    ???
+
+  def featureToAsInt(to: String): Int =
+    ???
+
   def commentTopic(c: Comment): UniProtGraph.CommentTopics =
     c match {
       case _ => ???

--- a/src/main/scala/uniprot/conversions.scala
+++ b/src/main/scala/uniprot/conversions.scala
@@ -4,8 +4,83 @@ import com.bio4j.model._
 import com.bio4j.angulillos._
 import scala.xml._
 import scala.compat.java8.OptionConverters._
+import bio4j.data.uniprot._
 
 case object conversions {
+
+  def statusToDatasets(status: Status): UniProtGraph.Datasets =
+    status match {
+      case Reviewed   => UniProtGraph.Datasets.swissProt
+      case Unreviewed => UniProtGraph.Datasets.trEMBL
+    }
+
+  def proteinExistenceToExistenceEvidence(prEx: ProteinExistence): UniProtGraph.ExistenceEvidence =
+    prEx match {
+      case EvidenceAtProteinLevel     => UniProtGraph.ExistenceEvidence.proteinLevel
+      case EvidenceAtTranscriptLevel  => UniProtGraph.ExistenceEvidence.transcriptLevel
+      case InferredFromHomology       => UniProtGraph.ExistenceEvidence.homologyInferred
+      case Predicted                  => UniProtGraph.ExistenceEvidence.predicted
+      case Uncertain                  => UniProtGraph.ExistenceEvidence.uncertain
+    }
+
+  def organelleToGeneLocation(org: Organelle): UniProtGraph.GeneLocations =
+    org match {
+      case Apicoplast               => UniProtGraph.GeneLocations.apicoplast
+      case Chloroplast              => UniProtGraph.GeneLocations.chloroplast
+      case OrganellarChromatophore  => UniProtGraph.GeneLocations.organellar_chromatophore
+      case Cyanelle                 => UniProtGraph.GeneLocations.cyanelle
+      case Hydrogenosome            => UniProtGraph.GeneLocations.hydrogenosome
+      case Mitochondrion            => UniProtGraph.GeneLocations.mitochondrion
+      case NonPhotosyntheticPlastid => UniProtGraph.GeneLocations.non_photosynthetic_plastid
+      case Nucleomorph              => UniProtGraph.GeneLocations.nucleomorph
+      case Plasmid(_)               => UniProtGraph.GeneLocations.plasmid
+      case Plastid                  => UniProtGraph.GeneLocations.plastid
+    }
+
+  def featureKeyToFeatureType(ftKey: FeatureKey): UniProtGraph.FeatureTypes =
+    ftKey match {
+      case INIT_MET   => UniProtGraph.FeatureTypes.initiatorMethionine
+      case SIGNAL     => UniProtGraph.FeatureTypes.signalPeptide
+      case PROPEP     => UniProtGraph.FeatureTypes.propeptide
+      case TRANSIT    => UniProtGraph.FeatureTypes.transitPeptide
+      case CHAIN      => UniProtGraph.FeatureTypes.chain
+      case PEPTIDE    => UniProtGraph.FeatureTypes.peptide
+      case TOPO_DOM   => UniProtGraph.FeatureTypes.topologicalDomain
+      case TRANSMEM   => UniProtGraph.FeatureTypes.transmembraneRegion
+      case INTRAMEM   => UniProtGraph.FeatureTypes.intramembraneRegion
+      case DOMAIN     => UniProtGraph.FeatureTypes.domain
+      case REPEAT     => UniProtGraph.FeatureTypes.repeat
+      case CA_BIND    => UniProtGraph.FeatureTypes.calciumBindingRegion
+      case ZN_FING    => UniProtGraph.FeatureTypes.zincFingerRegion
+      case DNA_BIND   => UniProtGraph.FeatureTypes.DNABindingRegion
+      case NP_BIND    => UniProtGraph.FeatureTypes.nucleotidePhosphateBindingRegion
+      case REGION     => UniProtGraph.FeatureTypes.regionOfInterest
+      case COILED     => UniProtGraph.FeatureTypes.coiledCoilRegion
+      case MOTIF      => UniProtGraph.FeatureTypes.shortSequenceMotif
+      case COMPBIAS   => UniProtGraph.FeatureTypes.compositionallyBiasedRegion
+      case ACT_SITE   =>  UniProtGraph.FeatureTypes.activeSite
+      case METAL      => UniProtGraph.FeatureTypes.metalIonBindingSite
+      case BINDING    => UniProtGraph.FeatureTypes.bindingSite
+      case SITE       => UniProtGraph.FeatureTypes.site
+      case NON_STD    => UniProtGraph.FeatureTypes.nonstandardAminoAcid
+      case MOD_RES    => UniProtGraph.FeatureTypes.modifiedResidue
+      case LIPID      => UniProtGraph.FeatureTypes.lipidMoietyBindingRegion
+      case CARBOHYD   => UniProtGraph.FeatureTypes.glycosylationSite
+      case DISULFID   => UniProtGraph.FeatureTypes.disulfideBond
+      case CROSSLNK   => UniProtGraph.FeatureTypes.crosslink
+      case VAR_SEQ    => UniProtGraph.FeatureTypes.spliceVariant
+      case VARIANT    => UniProtGraph.FeatureTypes.sequenceVariant
+      case MUTAGEN    => UniProtGraph.FeatureTypes.mutagenesisSite
+      case UNSURE     => UniProtGraph.FeatureTypes.unsureResidue
+      case CONFLICT   => UniProtGraph.FeatureTypes.sequenceConflict
+      case NON_CONS   => UniProtGraph.FeatureTypes.nonConsecutiveResidues
+      case NON_TER    => UniProtGraph.FeatureTypes.nonTerminalResidue
+      case HELIX      => UniProtGraph.FeatureTypes.helix
+      case STRAND     => UniProtGraph.FeatureTypes.strand
+      case TURN       => UniProtGraph.FeatureTypes.turn
+    }
+
+  
 
   val stringToGeneLocation: String => UniProtGraph.GeneLocations =
     {

--- a/src/main/scala/uniprot/uniprot.scala
+++ b/src/main/scala/uniprot/uniprot.scala
@@ -14,6 +14,14 @@ case class ImportUniProt[V,E](val graph: UniProtGraph[V,E]) {
 
   type G = UniProtGraph[V,E]
 
+  /*
+    ## UniProt entry data
+
+    Here we import all data that is derived from one UniProt entry. This method assumes that the following has been already imported:
+
+    - keyword types
+    - ...
+  */
   def dataFrom(e: FEntry, g: G): G = {
 
     val entryProteinAccession =
@@ -40,7 +48,9 @@ case class ImportUniProt[V,E](val graph: UniProtGraph[V,E]) {
     val existence =
       conversions.proteinExistenceToExistenceEvidence( e.proteinExistence )
 
-    /* All properties are set at this point */
+    /*
+      All protein properties are set at this point:
+    */
     val entryProtein =
       g.protein.addVertex
         .set(g.protein.id,              entryProteinID)
@@ -51,14 +61,25 @@ case class ImportUniProt[V,E](val graph: UniProtGraph[V,E]) {
         .set(g.protein.sequenceLength,  e.sequenceHeader.length: Integer )
         .set(g.protein.mass,            e.sequenceHeader.molecularWeight: Integer)
 
-    /* Gene names */
-    val geneNames = (e.geneNames map { gn => gn.name.fold(gn.ORFNames.headOption)(n => Some(n.official)) }).flatten
+    /*
+
+      ### Gene names and their edges
+
+      Gene names are ...
+    */
+    val geneNames =
+      e.geneNames
+        .map( gn =>
+          gn.name.fold(gn.ORFNames.headOption)(n => Some(n.official))
+        )
+        .flatten
 
     geneNames.foreach { n =>
 
       val gn =
-        g.geneName.name.index.find(n).asScala getOrElse
-        g.geneName.addVertex
+        g.geneName.name.index.find(n)
+          .asScala
+          .getOrElse( g.geneName.addVertex )
           .set(g.geneName.name, n)
 
       // add edges
@@ -66,240 +87,119 @@ case class ImportUniProt[V,E](val graph: UniProtGraph[V,E]) {
         // .setProperty(g.geneProducts, ???) // gene locations?
     }
 
-    /* Protein keywords. This needs the keyword types beforehand */
-    val keywords = e.keywords
+    /*
+      ### Protein keywords
+
+      This needs the keyword types beforehand.
+    */
+    val keywords =
+      e.keywords
+
     keywords.foreach { kw =>
       g.keyword.id.index.find(kw.id).asScala.foreach { kwt =>
         g.keywords.addEdge(entryProtein, kwt)
       }
     }
 
-    /* Other (non-isoform) comments */
+    /*
+      ### Protein comments
+
+    */
     val entryComments: Seq[Comment] = ??? // comments filterNot { x => x.isInstanceOf[Isoform] } // TODO enable isInstanceOf here
     entryComments
       .map( cc =>
         g.comment.addVertex
           .set(g.comment.topic, conversions.commentTopic(cc))
-          // .set(g.comment.text,  cc.text) needs bio4j/data.uniprot#19
+          // .set(g.comment.text,  cc.text) // TODO needs bio4j/data.uniprot#19 or something similar
       )
       .foreach { cv =>
         g.comments.addEdge(entryProtein, cv)
+      }
+    /*
+      ### Protein annotations
+
+    */
+      val proteinOpt =
+        graph.protein.accession.index.find( e.accessionNumbers.primary ).asScala
+
+      proteinOpt.foreach { protein =>
+
+        e.features foreach { feature =>
+
+          val annotation =
+            g.annotation.addVertex
+              .set(g.annotation.featureType, conversions.featureKeyToFeatureType(feature.key))
+              .set(g.annotation.description, feature.description)
+
+          g.annotations.addEdge(protein, annotation)
+            .set(g.annotations.begin, conversions.featureFromAsInt(feature.from): Integer)
+            .set(g.annotations.end, conversions.featureToAsInt(feature.to): Integer)
+        }
       }
 
     g
   }
 
-}
-
-
-case class Process[V,E](val graph: UniProtGraph[V,E]) {
-
-  type G = UniProtGraph[V,E]
-
-  val entryProteins =
-    GraphProcess.generically[V,E] (
-      graph,
-      (entry: FEntry, g: G) =>
-        (
-          graph,
-          g.protein.addVertex
-          .set(g.protein.id, entry.accessionNumbers.primary) // TODO get from canonical isoform etc
-          .set(g.protein.accession, entry.accessionNumbers.primary)
-          .set(g.protein.fullName,  entry.description.recommendedName.map(_.full) getOrElse entry.description.submittedNames.head.full )
-          .set(g.protein.existence, conversions.proteinExistenceToExistenceEvidence(entry.proteinExistence))
-          .set(g.protein.dataset, conversions.statusToDatasets(entry.identification.status))
-          .set(g.protein.sequence, entry.sequence.value)
-          .set(g.protein.sequenceLength, entry.sequenceHeader.length: Integer)
-        )
-    )
-
-
   /*
-    Import gene names vertices, and the geneProducts edge from gene names to entry proteins. Proteins should be already imported.
-  */
-  val entryGeneNames =
-    GraphProcess.generically[V,E](
-      graph,
-      (entry: Entry, g: G) => {
+    ## Isoforms
 
-        // if there's no gene name, empty, otherwise try to find if it's already imported, if not add it
-        val geneNames =
-          entry.geneName
-            .fold( Seq[G#GeneName]() ) {
-              name =>
-              g.geneName.name.index.find(name).asScala
-              .fold(
-                Seq(
-                  g.geneName.addVertex
-                  .set(g.geneName.name, name)
-                )
-              ){ Seq(_) }
-            }
-
-        /* Add geneProducts edges to the entry protein. Proteins should be imported before. */
-        g.protein.accession.index.find( entry.accession ).asScala.foreach {
-          protein => geneNames foreach {
-            geneName =>
-              g.geneProducts.addEdge(geneName, protein)
-                .set(g.geneProducts.location, entry.geneLocation)
-          }
-        }
-
-        (graph, geneNames)
-      }
-    )
-
-
-  /*
-    Import entry-level comment annotations, and the comments edges from entry proteins to comments. Entry proteins should be already imported.
-  */
-  val comments =
-    GraphProcess.generically[V,E](
-      graph,
-      (entry: Entry, g: UniProtGraph[V,E]) => {
-
-        val comments =
-          entry.comments map {
-            case (topic, text) =>
-              g.comment.addVertex
-                .set(g.comment.topic, topic)
-                .set(g.comment.text, text)
-          }
-
-        // add edges from proteins to these comments; I'm forced to do this here.
-        val proteinOpt =
-          graph.protein.accession.index.find( entry.accession ).asScala.foreach {
-            protein => comments.foreach {
-              comment => g.comments.addEdge( protein, comment )
-            }
-          }
-
-        (graph, comments)
-      }
-    )
-
-  /*
-    Import all the keyword types. This does not need anything beforehand.
-  */
-  val keywordTypes =
-    GraphProcess.generically[V,E](
-      graph,
-      (row: KeywordRow, g: G) =>
-        (
-          graph,
-          Seq(
-            g.keyword.addVertex
-              .set(g.keyword.id, row.id)
-              .set(g.keyword.definition, row.description)
-              .set(g.keyword.category, conversions.stringToKeywordCategory(row.category))
-          )
-        )
-    )
-
-  val keywords =
-    GraphProcess.generically[V,E](
-      graph,
-      (entry: Entry, g: UniProtGraph[V,E]) => {
-
-        val keywords = entry.keywordIDs.map(g.keyword.id.index.find(_).asScala).flatten
-
-        g.protein.accession.index.find(entry.accession).asScala foreach {
-          protein => keywords foreach {
-            keyword => g.keywords.addEdge(protein, keyword)
-          }
-        }
-
-        (graph, keywords)
-      }
-    )
-
-  /*
-    Import sequence annotations (features), including the annotations edge from entry proteins to their annotations. This needs the entry proteins.
-  */
-  val annotations =
-    GraphProcess.generically[V,E](
-      graph,
-      (entry: Entry, g: UniProtGraph[V,E]) => {
-
-        val proteinOpt =
-          graph.protein.accession.index.find( entry.accession ).asScala
-
-        val importedAnnotations = entry.features map {
-          case (featureType, maybeDescription, uniProtLocation) =>
-
-            val annotation =
-              g.annotation.addVertex
-
-            maybeDescription.foreach { annotation.set(g.annotation.description, _) }
-
-            val location = ZeroHalfOpenLocation.fromUniProtLocation(uniProtLocation)
-
-            // again forced to create this edge along the way
-            proteinOpt.foreach { protein =>
-              g.annotations.addEdge(protein, annotation)
-                .set(g.annotations.begin, location.begin: java.lang.Integer)
-                .set(g.annotations.end, location.end: java.lang.Integer)
-            }
-
-            annotation
-        }
-
-        (graph, importedAnnotations)
-      }
-    )
-
-  /*
     Import the isoforms, and add isoforms edges from the entry protein to the isoforms described there. Needs the entry proteins imported before.
   */
-  val isoforms =
-    GraphProcess.generically[V,E](
-      graph,
-      (entry: Entry, g: UniProtGraph[V,E]) => {
+  def isoformsFrom(e: FEntry, g: G): G = {
 
-        val maybeEntryProtein = g.protein.accession.index.find(entry.accession).asScala
+    val isoforms =
+      (e.comments collect { case i: Isoform => i })
+      .filterNot(_.isEntry)
 
-        val importedIsoforms = entry.isoforms map {
-          case (id, name) => {
+    val maybeEntryProtein = g.protein.accession.index.find(e.accessionNumbers.primary).asScala
 
-            g.protein.id.index.find(id).asScala.fold(
-              { // need to add the new isoform
-                val isoform = g.protein.addVertex
-                  .set(g.protein.id, id)
-                  .set(g.protein.fullName, name)
+    isoforms foreach { isoform =>
 
-                maybeEntryProtein.foreach { protein => g.isoforms.addEdge(protein, isoform) }
+      g.protein.id.index.find(isoform.id).asScala.fold(
+        { // need to add the new isoform
+          val isoformV = g.protein.addVertex
+            .set(g.protein.id, isoform.id)
+            .set(g.protein.fullName, s"${e.description.recommendedName
+              .fold(e.description.submittedNames.head.full)(_.full)} ${isoform.name}")
 
-                isoform
-              }
-            ){ // already there; add an edge from the current entry protein
-              isoform =>
-                maybeEntryProtein.foreach { protein => g.isoforms.addEdge(protein, isoform) }
-                isoform
-            }
-          }
+          maybeEntryProtein.foreach { protein => g.isoforms.addEdge(protein, isoformV) }
         }
-
-        (graph, importedIsoforms)
+      ){ // already there; add an edge from the current entry protein
+        isoform =>
+          maybeEntryProtein.foreach { protein => g.isoforms.addEdge(protein, isoform) }
       }
-    )
+    }
 
-  val isoformSequences =
-    GraphProcess.generically[V,E](
-      graph,
-      (fasta: IsoformFasta, g: G) => {
+    g
+  }
 
-        val isoformOpt = g.protein.id.index.find(fasta.proteinID).asScala
+  /*
+    ## Isoform sequences
+  */
+  def isoformSequencesFrom(fasta: IsoformFasta, g: G): G = {
 
-        isoformOpt.foreach {
-          isoform =>
-          val seq = fasta.sequence
+    g.protein.id.index.find(fasta.proteinID).asScala.foreach { isoform =>
 
-          isoform
+      val seq =
+        fasta.sequence
+
+      val isoformWithSeq =
+        isoform
           .set(g.protein.sequence, seq)
           .set(g.protein.sequenceLength, seq.length: java.lang.Integer)
-        }
+    }
 
-        (graph, isoformOpt)
-      }
-    )
+    g
+  }
+
+  def keywordTypesFrom(row: KeywordRow, g: G): G = {
+
+    val kwType =
+      g.keyword.addVertex
+        .set(g.keyword.id, row.id)
+        .set(g.keyword.definition, row.description)
+        .set(g.keyword.category, conversions.stringToKeywordCategory(row.category))
+
+    g
+  }
 }

--- a/src/main/scala/uniprot/uniprot.scala
+++ b/src/main/scala/uniprot/uniprot.scala
@@ -3,12 +3,94 @@ package com.bio4j.data.uniprot
 import com.bio4j.data._
 import com.bio4j.model._
 import com.bio4j.angulillos._
-import scala.xml._
 import scala.compat.java8.OptionConverters._
 import bio4j.data.uniprot.flat.{ Entry => FEntry }
+import bio4j.data.uniprot._
 
 // from keywords-all.tsv
 case class KeywordRow(val id: String, val description: String, val category: String)
+
+case class ImportUniProt[V,E](val graph: UniProtGraph[V,E]) {
+
+  type G = UniProtGraph[V,E]
+
+  def dataFrom(e: FEntry, g: G): G = {
+
+    val entryProteinAccession =
+      e.accessionNumbers.primary
+
+    // we need comments first, as isoforms are always there
+    val comments =
+      e.comments
+
+    val isoforms =
+      comments collect { case i: Isoform => i }
+
+    val entryProteinID =
+      isoforms.filter(_.isEntry).headOption.fold(entryProteinAccession)(_.id)
+
+    // either there's a recommended name or a submitted name
+    val entryProteinFullName =
+      e.description.recommendedName
+        .fold(e.description.submittedNames.head.full)(_.full)
+
+    val dataset =
+      conversions.statusToDatasets( e.identification.status )
+
+    val existence =
+      conversions.proteinExistenceToExistenceEvidence( e.proteinExistence )
+
+    /* All properties are set at this point */
+    val entryProtein =
+      g.protein.addVertex
+        .set(g.protein.id,              entryProteinID)
+        .set(g.protein.accession,       entryProteinAccession)
+        .set(g.protein.fullName,        entryProteinFullName)
+        .set(g.protein.dataset,         dataset)
+        .set(g.protein.sequence,        e.sequence.value)
+        .set(g.protein.sequenceLength,  e.sequenceHeader.length: Integer )
+        .set(g.protein.mass,            e.sequenceHeader.molecularWeight: Integer)
+
+    /* Gene names */
+    val geneNames = (e.geneNames map { gn => gn.name.fold(gn.ORFNames.headOption)(n => Some(n.official)) }).flatten
+
+    geneNames.foreach { n =>
+
+      val gn =
+        g.geneName.name.index.find(n).asScala getOrElse
+        g.geneName.addVertex
+          .set(g.geneName.name, n)
+
+      // add edges
+      g.geneProducts.addEdge(gn, entryProtein)
+        // .setProperty(g.geneProducts, ???) // gene locations?
+    }
+
+    /* Protein keywords. This needs the keyword types beforehand */
+    val keywords = e.keywords
+    keywords.foreach { kw =>
+      g.keyword.id.index.find(kw.id).asScala.foreach { kwt =>
+        g.keywords.addEdge(entryProtein, kwt)
+      }
+    }
+
+    /* Other (non-isoform) comments */
+    val entryComments: Seq[Comment] = ??? // comments filterNot { x => x.isInstanceOf[Isoform] } // TODO enable isInstanceOf here
+    entryComments
+      .map( cc =>
+        g.comment.addVertex
+          .set(g.comment.topic, conversions.commentTopic(cc))
+          // .set(g.comment.text,  cc.text) needs bio4j/data.uniprot#19
+      )
+      .foreach { cv =>
+        g.comments.addEdge(entryProtein, cv)
+      }
+
+    g
+  }
+
+}
+
 
 case class Process[V,E](val graph: UniProtGraph[V,E]) {
 
@@ -17,24 +99,20 @@ case class Process[V,E](val graph: UniProtGraph[V,E]) {
   val entryProteins =
     GraphProcess.generically[V,E] (
       graph,
-      (entry: FEntry, g: G) => {
-
+      (entry: FEntry, g: G) =>
         (
           graph,
-          Seq (
-            g.protein.addVertex
-            .set(g.protein.id, entry.accessionNumbers.primary) // TODO get from canonical isoform etc
-            .set(g.protein.accession, entry.accessionNumbers.primary)
-            .set(g.protein.fullName,  entry.description.recommendedName.map(_.full) getOrElse entry.description.submittedNames.head.full )
-            .set(g.protein.existence, conversions.proteinExistenceToExistenceEvidence(entry.proteinExistence))
-            .set(g.protein.dataset, conversions.statusToDatasets(entry.identification.status))
-            .set(g.protein.sequence, entry.sequence.value)
-            .set(g.protein.sequenceLength, entry.sequenceHeader.length: Integer)
-          )
+          g.protein.addVertex
+          .set(g.protein.id, entry.accessionNumbers.primary) // TODO get from canonical isoform etc
+          .set(g.protein.accession, entry.accessionNumbers.primary)
+          .set(g.protein.fullName,  entry.description.recommendedName.map(_.full) getOrElse entry.description.submittedNames.head.full )
+          .set(g.protein.existence, conversions.proteinExistenceToExistenceEvidence(entry.proteinExistence))
+          .set(g.protein.dataset, conversions.statusToDatasets(entry.identification.status))
+          .set(g.protein.sequence, entry.sequence.value)
+          .set(g.protein.sequenceLength, entry.sequenceHeader.length: Integer)
         )
-      }
-
     )
+
 
   /*
     Import gene names vertices, and the geneProducts edge from gene names to entry proteins. Proteins should be already imported.


### PR DESCRIPTION
- [ ] conversions should now go from the data.uniprot entry types to bio4j/bio4j (gene locations, comment topics, etc)
- [x] re-implement simple manipulations like the entry isoform id etc using the data.uniprot entry type
- [ ] add location parsing and conversion to reasonable 0-based half-open intervals
